### PR TITLE
Reconfigure Arduino Lint CI for Library Manager

### DIFF
--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -22,7 +22,7 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           compliance: specification
-          library-manager: submit
+          library-manager: update
           # Always use this setting for official repositories. Remove for 3rd party projects.
           official: true
           project-type: library


### PR DESCRIPTION
[Arduino Lint](https://arduino.github.io/arduino-lint/latest/), which is used in the "Check Arduino" CI workflow, checks for compliance with the [requirements for submission](https://github.com/arduino/library-registry/blob/main/FAQ.md#what-are-the-requirements-for-a-library-to-be-added-to-library-manager) of a library into the Library Manager index, as well as for the [requirements for releases](https://github.com/arduino/library-registry/blob/main/FAQ.md#what-are-the-requirements-for-publishing-new-releases-of-libraries-already-in-the-library-manager-list) of the library to be indexed once it is accepted. Since some of these requirements are contradictory, Arduino Lint must be configured according to the library's status.

In GitHub Actions workflows, this configuration is done via the `arduino/arduino-lint-action` action's [`library-manager`
input](https://github.com/arduino/arduino-lint-action#library-manager).

Now that the library has been accepted into the Library Manager index (https://github.com/arduino/library-registry/pull/131), the "update" configuration must be used.